### PR TITLE
useAccount hook

### DIFF
--- a/src/api/polkadot/connectApi.ts
+++ b/src/api/polkadot/connectApi.ts
@@ -16,7 +16,7 @@ interface InjectedAccountExt {
 
 const injectedPromise = web3Enable('polkadot-js/apps');
 
-export const loadAccounts = async (api: ApiPromise) => {
+const loadAccounts = async (api: ApiPromise) => {
     // wait for the WASM crypto libraries to load first
     await cryptoWaitReady();
 
@@ -46,8 +46,6 @@ export const loadAccounts = async (api: ApiPromise) => {
         },
         injectedAccounts,
     );
-
-    return keyring;
 };
 
 export const connectApi = async (endpoint: string) => {
@@ -62,6 +60,12 @@ export const connectApi = async (endpoint: string) => {
         provider,
         types,
     }).isReady;
+
+    try {
+        await loadAccounts(api);
+    } catch (err) {
+        console.error(err);
+    }
 
     // load the web3 extension
     injectedPromise.then((): void => {}).catch((error: Error) => console.error(error));

--- a/src/api/polkadot/connectApi.ts
+++ b/src/api/polkadot/connectApi.ts
@@ -1,9 +1,10 @@
 import { ApiPromise } from '@polkadot/api';
-import keyring from '@polkadot/ui-keyring';
+import { keyring } from '@polkadot/ui-keyring';
 import { web3Accounts, web3Enable } from '@polkadot/extension-dapp';
 import { isTestChain } from '@polkadot/util';
 import { WsProvider } from '@polkadot/rpc-provider';
 import * as plasmDefinitions from '@plasm/types/interfaces/definitions';
+import { cryptoWaitReady } from '@polkadot/util-crypto';
 
 interface InjectedAccountExt {
     address: string;
@@ -15,7 +16,10 @@ interface InjectedAccountExt {
 
 const injectedPromise = web3Enable('polkadot-js/apps');
 
-async function loadAccounts(api: ApiPromise): Promise<void> {
+export const loadAccounts = async (api: ApiPromise) => {
+    // wait for the WASM crypto libraries to load first
+    await cryptoWaitReady();
+
     const [systemChain, injectedAccounts] = await Promise.all([
         api.rpc.system.chain() as any,
         web3Accounts().then((accounts): InjectedAccountExt[] =>
@@ -42,9 +46,11 @@ async function loadAccounts(api: ApiPromise): Promise<void> {
         },
         injectedAccounts,
     );
-}
 
-export const connectApi = async (endpoint: string): Promise<ApiPromise> => {
+    return keyring;
+};
+
+export const connectApi = async (endpoint: string) => {
     const provider = new WsProvider(endpoint);
 
     const types = Object.values(plasmDefinitions).reduce(
@@ -57,11 +63,8 @@ export const connectApi = async (endpoint: string): Promise<ApiPromise> => {
         types,
     }).isReady;
 
-    try {
-        await loadAccounts(api);
-    } catch (error) {
-        console.error('Unable to load chain', error);
-    }
+    // load the web3 extension
+    injectedPromise.then((): void => {}).catch((error: Error) => console.error(error));
 
     return api;
 };

--- a/src/api/polkadot/polkadotContext.ts
+++ b/src/api/polkadot/polkadotContext.ts
@@ -1,12 +1,18 @@
 import { provide, inject, reactive, toRefs, readonly } from 'vue';
 import { ApiPromise } from '@polkadot/api/promise';
-
+import keyring from '@polkadot/ui-keyring';
+import type { KeyringPair } from '@polkadot/keyring/types';
+import { AccountInfo, Balance } from '../models';
+import { UnsubscribePromise } from '@polkadot/api/types';
 // note: this is a simplified Redux-like state management pattern using the Vue composition API.
 // unlike Vuex; this method is not very strict, meaning that if someone really wanted to,
 // they could just directly inject the raw state symbol and mutate it
 
 interface ProviderState {
     api: null | ApiPromise;
+    currentAccount: null | KeyringPair;
+    currentBalance: null | Balance;
+    unsubscribeAccountInfo: null | UnsubscribePromise;
     testCounter: number;
 }
 
@@ -14,6 +20,10 @@ interface ProviderState {
 const state = reactive<ProviderState>({
     // start with an empty api object
     api: null,
+    // start with an empty object
+    currentAccount: null,
+    currentBalance: null,
+    unsubscribeAccountInfo: null,
     // fixme: this value is purely for testing the injection method
     testCounter: 0,
 });
@@ -22,6 +32,36 @@ const state = reactive<ProviderState>({
 const mutations = {
     setApi: (apiInst: ApiPromise) => {
         state.api = apiInst;
+    },
+    setCurrentAccount: (accountIndex: number) => {
+        const api = state.api;
+        if (api === null) {
+            return;
+        }
+
+        const accounts = keyring.getPairs();
+        const accountsLength = accounts.length;
+        if (accountsLength === 0 || accountIndex > accountsLength || accountIndex < 0) {
+            return;
+        }
+        // unsubscribe previous AccountInfo
+        const unsub = state.unsubscribeAccountInfo;
+        if (unsub) {
+            (async function () {
+                (await unsub)();
+            })();
+        }
+
+        const currentAccount = accounts[accountIndex];
+        state.currentAccount = currentAccount;
+
+        // subscribe current AccountInfo
+        state.unsubscribeAccountInfo = api.query.system.account(
+            currentAccount.address,
+            (result) => {
+                state.currentBalance = result.data.free.toBn();
+            },
+        );
     },
     setCounter: (val: number) => {
         state.testCounter = val;

--- a/src/api/polkadot/polkadotContext.ts
+++ b/src/api/polkadot/polkadotContext.ts
@@ -8,12 +8,8 @@ import { UnsubscribePromise } from '@polkadot/api/types';
 // unlike Vuex; this method is not very strict, meaning that if someone really wanted to,
 // they could just directly inject the raw state symbol and mutate it
 
-// type alias for the global keyring instance
-type KeyringUi = typeof keyring;
-
 interface ProviderState {
     api: null | ApiPromise;
-    keyring: null | KeyringUi;
     currentAccount: null | KeyringPair;
     currentBalance: null | Balance;
     unsubscribeAccountInfo: null | UnsubscribePromise;
@@ -24,7 +20,6 @@ interface ProviderState {
 const state = reactive<ProviderState>({
     // start with an empty api object
     api: null,
-    keyring: null,
     // start with an empty object
     currentAccount: null,
     currentBalance: null,
@@ -37,9 +32,6 @@ const state = reactive<ProviderState>({
 const mutations = {
     setApi: (apiInst: ApiPromise) => {
         state.api = apiInst;
-    },
-    setKeyring: (keyringInst: KeyringUi) => {
-        state.keyring = keyringInst;
     },
     setCurrentAccount: (accountIndex: number) => {
         const api = state.api;
@@ -82,9 +74,8 @@ type StateMutations = typeof mutations;
 const STATE_SYMBOL = Symbol('polkadot API read state');
 const MUTATION_SYMBOL = Symbol('polkadot API state mutation');
 
-export const providePolkadotContainer = (initApi: ApiPromise, keyringInst: KeyringUi) => {
+export const providePolkadotContainer = (initApi: ApiPromise) => {
     mutations.setApi(initApi);
-    mutations.setKeyring(keyringInst);
 
     // provide a readonly reference of the current state and mutation methods
     provide(STATE_SYMBOL, toRefs(readonly(state)));

--- a/src/api/utils/index.ts
+++ b/src/api/utils/index.ts
@@ -1,7 +1,7 @@
 import { ApiPromise } from '@polkadot/api';
 
-export function assertApiIsDefined(api?: ApiPromise): ApiPromise {
-    if (api === undefined) {
+export function assertApiIsDefined(api?: ApiPromise | null): ApiPromise {
+    if (api === undefined || api === null) {
         throw new Error('Polkadot api is undefined');
     }
     return api;

--- a/src/config/chainEndpoints.ts
+++ b/src/config/chainEndpoints.ts
@@ -22,7 +22,7 @@ export const providerEndpoints: ChainProvider[] = [
     {
         networkAlias: 'dusty-testnet',
         displayName: 'Dusty Plasm Network',
-        info: 'The main network of the layer 2 scaling blockchain, Plasm Network',
+        info: 'The test network of the layer 2 scaling blockchain, Dusty Plasm Network',
         endpoint: 'wss://rpc.plasmnet.io/',
     },
     localNode,

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,3 +1,22 @@
+import { App } from '@vue/runtime-core';
+
 export * from './useAccount';
 export * from './useApi';
+export * from './useBalance';
 export * from './useSidebar';
+
+interface Runtime {
+    app?: App;
+}
+
+const runtime: Runtime = {};
+
+export default function install(app: App) {
+    app.mixin({
+        created() {
+            if (typeof this.$options.setup === 'function') {
+                runtime.app = app;
+            }
+        },
+    });
+}

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,0 +1,3 @@
+export * from './useAccount';
+export * from './useApi';
+export * from './useSidebar';

--- a/src/hooks/providers/ApiLoader.vue
+++ b/src/hooks/providers/ApiLoader.vue
@@ -7,13 +7,13 @@
 <script lang="ts">
 import { defineComponent } from 'vue';
 import PolkadotProvider from './PolkadotProvider.vue';
-import { providerEndpoints } from '@/config';
+import { localNode } from '@/config';
 import { connectApi } from '@/api/polkadot';
 
 export default defineComponent({
     name: 'api-loader',
     async setup() {
-        const api = await connectApi(providerEndpoints[0].endpoint);
+        const api = await connectApi(localNode.endpoint);
 
         return {
             api,

--- a/src/hooks/providers/ApiLoader.vue
+++ b/src/hooks/providers/ApiLoader.vue
@@ -1,5 +1,5 @@
 <template>
-    <polkadot-provider :polkadotApi="api" :keyring="keyring">
+    <polkadot-provider :polkadotApi="api">
         <slot />
     </polkadot-provider>
 </template>
@@ -8,7 +8,7 @@
 import { defineComponent, ref } from 'vue';
 import PolkadotProvider from './PolkadotProvider.vue';
 import { providerEndpoints } from '@/config';
-import { connectApi, loadAccounts } from '@/api/polkadot';
+import { connectApi } from '@/api/polkadot';
 
 export default defineComponent({
     name: 'api-loader',
@@ -19,10 +19,8 @@ export default defineComponent({
         const endpoint = ref(dusty);
 
         const api = await connectApi(endpoint.value);
-        const keyring = await loadAccounts(api);
         return {
             api,
-            keyring,
         };
     },
     components: {

--- a/src/hooks/providers/ApiLoader.vue
+++ b/src/hooks/providers/ApiLoader.vue
@@ -1,22 +1,28 @@
 <template>
-    <polkadot-provider :polkadotApi="api">
+    <polkadot-provider :polkadotApi="api" :keyring="keyring">
         <slot />
     </polkadot-provider>
 </template>
 
 <script lang="ts">
-import { defineComponent } from 'vue';
+import { defineComponent, ref } from 'vue';
 import PolkadotProvider from './PolkadotProvider.vue';
-import { localNode } from '@/config';
-import { connectApi } from '@/api/polkadot';
+import { providerEndpoints } from '@/config';
+import { connectApi, loadAccounts } from '@/api/polkadot';
 
 export default defineComponent({
     name: 'api-loader',
     async setup() {
-        const api = await connectApi(localNode.endpoint);
+        const dusty = providerEndpoints[1].endpoint;
+        //const local = providerEndpoints[2].endpoint;
 
+        const endpoint = ref(dusty);
+
+        const api = await connectApi(endpoint.value);
+        const keyring = await loadAccounts(api);
         return {
             api,
+            keyring,
         };
     },
     components: {

--- a/src/hooks/providers/PolkadotProvider.vue
+++ b/src/hooks/providers/PolkadotProvider.vue
@@ -3,20 +3,22 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from 'vue';
+import { defineComponent, PropType } from 'vue';
 import { providePolkadotContainer } from '@/api/polkadot';
 import { ApiPromise } from '@polkadot/api';
+import { keyring } from '@polkadot/ui-keyring';
 
 export default defineComponent({
     name: 'polkadot-provider',
     props: {
-        polkadotApi: ApiPromise,
+        polkadotApi: { type: Object as PropType<ApiPromise>, required: true },
+        keyring: { type: Object as PropType<typeof keyring>, required: true },
     },
     setup(props) {
         // we use the api instance that was passed as a prop to inject data
         // note: trying to use the `provide()` function within a promise wrapper may cause unexpected behavior
-        if (props.polkadotApi) {
-            providePolkadotContainer(props.polkadotApi);
+        if (props.polkadotApi && props.keyring) {
+            providePolkadotContainer(props.polkadotApi, props.keyring);
         }
     },
 });

--- a/src/hooks/providers/PolkadotProvider.vue
+++ b/src/hooks/providers/PolkadotProvider.vue
@@ -6,19 +6,17 @@
 import { defineComponent, PropType } from 'vue';
 import { providePolkadotContainer } from '@/api/polkadot';
 import { ApiPromise } from '@polkadot/api';
-import { keyring } from '@polkadot/ui-keyring';
 
 export default defineComponent({
     name: 'polkadot-provider',
     props: {
         polkadotApi: { type: Object as PropType<ApiPromise>, required: true },
-        keyring: { type: Object as PropType<typeof keyring>, required: true },
     },
     setup(props) {
         // we use the api instance that was passed as a prop to inject data
         // note: trying to use the `provide()` function within a promise wrapper may cause unexpected behavior
-        if (props.polkadotApi && props.keyring) {
-            providePolkadotContainer(props.polkadotApi, props.keyring);
+        if (props.polkadotApi) {
+            providePolkadotContainer(props.polkadotApi);
         }
     },
 });

--- a/src/hooks/useAccount.ts
+++ b/src/hooks/useAccount.ts
@@ -1,0 +1,10 @@
+import { usePolkadotContainerContext } from '@/api';
+
+/**
+ * Access the global polkadot API state that is provided by the provider component from a nested parent
+ */
+export const useAccount = () => {
+    const { currentAccount, currentBalance, setCurrentAccount } = usePolkadotContainerContext();
+
+    return { currentAccount, currentBalance, setCurrentAccount };
+};

--- a/src/hooks/useAccount.ts
+++ b/src/hooks/useAccount.ts
@@ -1,10 +1,49 @@
 import { usePolkadotContainerContext } from '@/api';
+import { useIsMountedRef } from './useIsMountedRef';
+import { reactive, toRefs, readonly, onMounted, watchEffect } from 'vue';
+import { keyring } from '@polkadot/ui-keyring';
+
+interface UseAccounts {
+    allAccounts: string[];
+    hasAccounts: boolean;
+    isAccount: (address: string) => boolean;
+}
 
 /**
- * Access the global polkadot API state that is provided by the provider component from a nested parent
+ * Access the global keyring state to get a readonly value of the list of loaded accounts in the page.
+ * The hooks should only be called from the `setup()` block of the vue component
  */
 export const useAccount = () => {
-    const { currentAccount, currentBalance, setCurrentAccount } = usePolkadotContainerContext();
+    const mountedRef = useIsMountedRef();
 
-    return { currentAccount, currentBalance, setCurrentAccount };
+    // set the initial value
+    let state = reactive<UseAccounts>({
+        allAccounts: [],
+        hasAccounts: false,
+        isAccount: () => false,
+    });
+
+    watchEffect((onInvalidate) => {
+        const subscription = keyring.accounts.subject.subscribe((accounts) => {
+            // only subscribe to the keyring if the component that originally called this hook is still mounted
+            if (mountedRef.value) {
+                const allAccounts = accounts ? Object.keys(accounts) : [];
+                const hasAccounts = allAccounts.length !== 0;
+                const isAccount = (address: string) => allAccounts.includes(address);
+
+                state = reactive({
+                    allAccounts,
+                    hasAccounts,
+                    isAccount,
+                });
+            }
+        });
+
+        // unsubscribe from the keyring if the parent component is unmounted
+        onInvalidate(() => {
+            subscription.unsubscribe();
+        });
+    });
+
+    return toRefs(readonly(state));
 };

--- a/src/hooks/useAccount.ts
+++ b/src/hooks/useAccount.ts
@@ -1,6 +1,5 @@
-import { usePolkadotContainerContext } from '@/api';
 import { useIsMountedRef } from './useIsMountedRef';
-import { reactive, toRefs, readonly, onMounted, watchEffect } from 'vue';
+import { reactive, toRefs, watchEffect } from 'vue';
 import { keyring } from '@polkadot/ui-keyring';
 
 interface UseAccounts {
@@ -17,25 +16,23 @@ export const useAccount = () => {
     const mountedRef = useIsMountedRef();
 
     // set the initial value
-    let state = reactive<UseAccounts>({
+    const state = reactive<UseAccounts>({
         allAccounts: [],
         hasAccounts: false,
         isAccount: () => false,
     });
 
     watchEffect((onInvalidate) => {
+        // fixme: this part is showing an error when fetching accounts
         const subscription = keyring.accounts.subject.subscribe((accounts) => {
             // only subscribe to the keyring if the component that originally called this hook is still mounted
             if (mountedRef.value) {
-                const allAccounts = accounts ? Object.keys(accounts) : [];
-                const hasAccounts = allAccounts.length !== 0;
-                const isAccount = (address: string) => allAccounts.includes(address);
+                // fixme: this is an unintuitive method to assign values. We need to find a scalable method
+                state.allAccounts = accounts ? Object.keys(accounts) : [];
+                state.hasAccounts = state.allAccounts.length !== 0;
+                state.isAccount = (address: string) => state.allAccounts.includes(address);
 
-                state = reactive({
-                    allAccounts,
-                    hasAccounts,
-                    isAccount,
-                });
+                console.log(state);
             }
         });
 
@@ -45,5 +42,5 @@ export const useAccount = () => {
         });
     });
 
-    return toRefs(readonly(state));
+    return toRefs(state);
 };

--- a/src/hooks/useBalance.ts
+++ b/src/hooks/useBalance.ts
@@ -1,0 +1,36 @@
+import { ref, onUnmounted, onMounted, watchEffect, Ref } from 'vue';
+import { useApi } from '@/hooks';
+import BN from 'bn.js';
+import { UnsubscribePromise } from '@polkadot/api/types';
+import { ApiPromise } from '@polkadot/api';
+
+export function useBalance(api: ApiPromise | null, address?: string) {
+    const balance = ref(new BN(0));
+    const balanceAccount = ref(address);
+    const setBalanceAccount = (address: string) => {
+        balanceAccount.value = address;
+    };
+    const unsub: Ref<null | UnsubscribePromise> = ref(null);
+
+    watchEffect(() => {
+        console.log('watchEffect triggered');
+        const balanceAccountValue = balanceAccount.value;
+        console.log(balanceAccountValue);
+        if (balanceAccountValue && api) {
+            console.log(api.isReady);
+            api.isReady.then(() => {
+                unsub.value = api.query.system.account(balanceAccountValue, (result) => {
+                    balance.value = result.data.free.toBn();
+                });
+            });
+        }
+    });
+
+    onUnmounted(() => {
+        console.log('onUnmounted');
+        (async function () {
+            await unsub.value?.then();
+        });
+    });
+    return { balance, setBalanceAccount };
+}

--- a/src/hooks/useIsMountedRef.ts
+++ b/src/hooks/useIsMountedRef.ts
@@ -1,0 +1,15 @@
+import { onMounted, onUnmounted, ref } from 'vue';
+
+export const useIsMountedRef = () => {
+    const isMounted = ref(false);
+
+    onMounted(() => {
+        isMounted.value = true;
+    });
+
+    onUnmounted(() => {
+        isMounted.value = false;
+    });
+
+    return isMounted;
+};

--- a/src/hooks/useIsMountedRef.ts
+++ b/src/hooks/useIsMountedRef.ts
@@ -3,6 +3,8 @@ import { onMounted, onUnmounted, ref } from 'vue';
 export const useIsMountedRef = () => {
     const isMounted = ref(false);
 
+    // todo: add context check for the current component
+
     onMounted(() => {
         isMounted.value = true;
     });

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,6 +3,7 @@ import { createApp } from 'vue';
 import App from './App.vue';
 import router from './router';
 import { store } from './store';
+import hooks from './hooks/index';
 import './assets/style/base.css';
 import './registerServiceWorker';
 import DashboardLayout from './layouts/DashboardLayout.vue';
@@ -15,5 +16,6 @@ app.component('empty-layout', EmptyLayout);
 
 app.use(router);
 app.use(store);
+// app.use(hooks);
 
 app.mount('#app');

--- a/src/views/Balance.vue
+++ b/src/views/Balance.vue
@@ -1,6 +1,6 @@
 <template>
     <h2 class="text-gray-400 text-3xl font-medium">Balance</h2>
-    <p class="text-gray-400">Account: {{ account ? account : 'no account selected' }}</p>
+    <p class="text-gray-400">Account: {{ allAccounts ? allAccounts[0] : 'no account selected' }}</p>
     <!-- <p class="text-gray-400">Balance: {{ balance ? balance.toString() : '0' }}</p> -->
     <p class="text-gray-400">Counter: {{ testCounter ? testCounter.toString() : '0' }}</p>
 
@@ -8,23 +8,24 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from 'vue';
+import { defineComponent, watchEffect } from 'vue';
 import { useApi, useAccount } from '@/hooks';
-// import { useBalance } from '@/hooks';
 
 export default defineComponent({
     setup() {
         const { api, testCounter } = useApi();
         const { allAccounts } = useAccount();
 
-        console.log(allAccounts.value);
-
-        const account = allAccounts.value[0];
+        watchEffect(() => {
+            // fixme: this part returns an empty value when the page changes (i.e., unmounted and remounted)
+            // whilst the value from the hook is correctly assigned
+            console.log(allAccounts.value);
+        });
 
         return {
             api,
             // balance,
-            account,
+            allAccounts,
             testCounter,
         };
     },

--- a/src/views/Balance.vue
+++ b/src/views/Balance.vue
@@ -3,27 +3,43 @@
     <p class="text-gray-400">
         Account: {{ currentAccount ? currentAccount.address : 'no account selected' }}
     </p>
-    <p class="text-gray-400">Balance: {{ balance ? balance.toString() : '0' }}</p>
+    <!-- <p class="text-gray-400">Balance: {{ balance ? balance.toString() : '0' }}</p> -->
     <p class="text-gray-400">Counter: {{ testCounter ? testCounter.toString() : '0' }}</p>
 
     <p class="text-gray-400">{{ api ? api.isConnected : 'no api' }}</p>
 </template>
 
 <script lang="ts">
-import { defineComponent } from 'vue';
+import { defineComponent, watch } from 'vue';
 import { useApi, useAccount } from '@/hooks';
+// import { useBalance } from '@/hooks';
 
 export default defineComponent({
     setup() {
         const { api, testCounter } = useApi();
-        const { currentAccount, currentBalance, setCurrentAccount } = useAccount();
-        const balance = currentBalance;
+        const { currentAccount, setCurrentAccount } = useAccount();
+        // let { balance, setBalanceAccount } = useBalance(
+        //     api,
+        //     '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY',
+        // );
 
         setCurrentAccount(0);
+        console.log('currentAccount: ' + currentAccount?.address);
+
+        watch(
+            () => currentAccount,
+            (currentAccount) => {
+                console.log('Balance.vue watch triggered');
+                if (currentAccount?.address) {
+                    console.log('currentAccount: ' + currentAccount.address);
+                    // setBalanceAccount(currentAccount.address);
+                }
+            },
+        );
 
         return {
             api,
-            balance,
+            // balance,
             currentAccount,
             testCounter,
         };

--- a/src/views/Balance.vue
+++ b/src/views/Balance.vue
@@ -1,8 +1,6 @@
 <template>
     <h2 class="text-gray-400 text-3xl font-medium">Balance</h2>
-    <p class="text-gray-400">
-        Account: {{ currentAccount ? currentAccount.address : 'no account selected' }}
-    </p>
+    <p class="text-gray-400">Account: {{ account ? account : 'no account selected' }}</p>
     <!-- <p class="text-gray-400">Balance: {{ balance ? balance.toString() : '0' }}</p> -->
     <p class="text-gray-400">Counter: {{ testCounter ? testCounter.toString() : '0' }}</p>
 
@@ -10,37 +8,23 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, watch } from 'vue';
+import { defineComponent } from 'vue';
 import { useApi, useAccount } from '@/hooks';
 // import { useBalance } from '@/hooks';
 
 export default defineComponent({
     setup() {
         const { api, testCounter } = useApi();
-        const { currentAccount, setCurrentAccount } = useAccount();
-        // let { balance, setBalanceAccount } = useBalance(
-        //     api,
-        //     '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY',
-        // );
+        const { allAccounts } = useAccount();
 
-        setCurrentAccount(0);
-        console.log('currentAccount: ' + currentAccount?.address);
+        console.log(allAccounts.value);
 
-        watch(
-            () => currentAccount,
-            (currentAccount) => {
-                console.log('Balance.vue watch triggered');
-                if (currentAccount?.address) {
-                    console.log('currentAccount: ' + currentAccount.address);
-                    // setBalanceAccount(currentAccount.address);
-                }
-            },
-        );
+        const account = allAccounts.value[0];
 
         return {
             api,
             // balance,
-            currentAccount,
+            account,
             testCounter,
         };
     },

--- a/src/views/Balance.vue
+++ b/src/views/Balance.vue
@@ -1,24 +1,30 @@
 <template>
     <h2 class="text-gray-400 text-3xl font-medium">Balance</h2>
+    <p class="text-gray-400">
+        Account: {{ currentAccount ? currentAccount.address : 'no account selected' }}
+    </p>
     <p class="text-gray-400">Balance: {{ balance ? balance.toString() : '0' }}</p>
     <p class="text-gray-400">Counter: {{ testCounter ? testCounter.toString() : '0' }}</p>
+
     <p class="text-gray-400">{{ api ? api.isConnected : 'no api' }}</p>
 </template>
 
 <script lang="ts">
-import BN from 'bn.js';
-import { defineComponent, reactive } from 'vue';
-import { Balance } from '@/api/models';
-import { useApi } from '@/hooks/useApi';
+import { defineComponent } from 'vue';
+import { useApi, useAccount } from '@/hooks';
 
 export default defineComponent({
     setup() {
-        const balance = reactive<Balance>(new BN(0));
         const { api, testCounter } = useApi();
+        const { currentAccount, currentBalance, setCurrentAccount } = useAccount();
+        const balance = currentBalance;
+
+        setCurrentAccount(0);
 
         return {
             api,
             balance,
+            currentAccount,
             testCounter,
         };
     },

--- a/src/views/DApps.vue
+++ b/src/views/DApps.vue
@@ -5,12 +5,20 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from 'vue';
+import { defineComponent, watch } from 'vue';
 import { useApi } from '@/hooks/useApi';
 
 export default defineComponent({
     setup() {
         const { api, testCounter, setCounter } = useApi();
+
+        watch(
+            () => testCounter,
+            (testCounter) => {
+                console.log('testCounter triggered');
+                console.log(testCounter);
+            },
+        );
 
         return {
             api,


### PR DESCRIPTION
# Pull Request Summary

create useAccount hook to get context data of `currentAccout`, `currentBalance`, `setCurrentAccount`.

## Check List

- [x] contains breaking changes
  - [x] adds new feature
  - [ ] modifies existing feature
- [x] other task relies on this pull request
- [ ] non-coding changes

## Change Log

This pull request makes the following changes:

### Adds

- add `currentAccount`, `currentBalance`, `setCurrentAccount`, unsubscribeCurrentAccount` to provider storage.
- create useAccount hook to derive`currentAccount`, `currentBalance`, `setCurrentAccount`.

### Changes

- show current account in `src/views/Balance.vue`