### PR TITLE
add public path config

### DIFF
--- a/vue.config.js
+++ b/vue.config.js
@@ -14,4 +14,5 @@ module.exports = {
   pwa: {
     name: 'plasm-apps',
   },
+  publicPath: process.env.NODE_ENV === 'production' ? '/plasm-apps-vue/' : '/',
 };


### PR DESCRIPTION
# Pull Request Summary

This pr adds the `publicPath` property to vue config so page resources can be served on github pages (ref: https://cli.vuejs.org/config/#publicpath).

**Note:** We may want to change this configuration later when we add a custom domain that serves the page in the root directory.

## Check List

- [ ] contains breaking changes
  - [ ] adds new feature
  - [ ] modifies existing feature
- [ ] other task relies on this pull request
- [x] non-coding changes

## Change Log

This pull request makes the following changes:

### Adds

- `publicPath` value in `vue.confg.js`

